### PR TITLE
Compatible version with K3 Keyboard (3.4.3

### DIFF
--- a/In the Kindle/launch.sh
+++ b/In the Kindle/launch.sh
@@ -1,5 +1,5 @@
 #! /bin/sh
 
-rm /linkss/screensavers/done.png
-wget -O "/linkss/screensavers/done.png" "http://path to your server/kindle/done.png"
-touch /linkss/screensavers/reboot
+rm /mnt/us/linkss/screensavers/done.png
+wget -O "/mnt/us/linkss/screensavers/done.png" "http://path to your server/kindle/done.png"
+reboot


### PR DESCRIPTION
Normally the empty reboot file needs to go in /linkss/ instead of the subdirectory.
(Point 5c) in https://wiki.mobileread.com/wiki/Kindle_Screen_Saver_Hack_for_all_2.x,_3.x_%26_4.x_Kindles)
But that didn't work either on my device. The previous reboot command does the job though.
Also I am using absolute paths that work. Not sure whether to prefer relative in this case.