### PR TITLE
fix for Pngcrush

### DIFF
--- a/In the server/launch.sh
+++ b/In the server/launch.sh
@@ -8,7 +8,7 @@ python3 programs/parse_ical.py
 rsvg-convert --background-color=white -o almost_done.png almost_done.svg
 
 #We optimize the image
-pngcrush -c 0 -ow almost_done.png done.png
+pngcrush -force -c 0 almost_done.png done.png
 
 #We move the image where it needs to be
 rm /var/www/kindle/done.png


### PR DESCRIPTION
The script and parser work with the exception of Pngcrush acting up.
With -ow (overwrite) option, Pngcrush did not produce output. 
I've added -force option to always produce output even if no optimisation is possible (colourspace adjustment is always necessary).

considering of course that I am using raspbian stretch on a raspberry pi 3 atm.